### PR TITLE
fix: indexes all completed statuses

### DIFF
--- a/lib/indexing_jobs_generator.rb
+++ b/lib/indexing_jobs_generator.rb
@@ -3,7 +3,7 @@ class IndexingJobsGenerator
   def self.match?(data)
     data["action"] == "JOB_END" &&
       data["job_instance"]["name"] == alma_job_name &&
-      data["job_instance"]["status"]["value"] == "COMPLETED_SUCCESS"
+      ["COMPLETED_SUCCESS", "COMPLETED_FAILED"].include?(data["job_instance"]["status"]["value"])
   end
 
   def initialize(data: nil, job_id: nil, sftp: SFTP.client, logger: Logger.new($stdout),

--- a/spec/lib/indexing_jobs_generator_spec.rb
+++ b/spec/lib/indexing_jobs_generator_spec.rb
@@ -89,7 +89,11 @@ describe DailyIndexingJobsGenerator do
     end
   end
   context ".match?" do
-    it "matches the correct job" do
+    it "matches the correct job and success status" do
+      expect(described_class.match?(@data)).to eq(true)
+    end
+    it "matches the correct job and success with errors status" do
+      @data["job_instance"]["status"]["value"] = "COMPLETED_FAILED"
       expect(described_class.match?(@data)).to eq(true)
     end
     it "does not match when it should not match" do


### PR DESCRIPTION
The events handler was skipping over `COMPLETED_FAILED` statuses, which still send records to the sftp server. Now those statuses also trigger indexing. 